### PR TITLE
The token value should be a UUID by default, but should be editable

### DIFF
--- a/endpoint/packages/user/admin_views.py
+++ b/endpoint/packages/user/admin_views.py
@@ -1,4 +1,5 @@
 import manage
+import uuid
 from flask_login import login_user, logout_user, current_user
 from flask_admin import BaseView, expose
 from flask_admin.contrib import sqla
@@ -25,3 +26,4 @@ class AdminGroupView(AuthModelView):
 
 class AdminTokenView(AuthModelView):
     column_exclude_list = []
+    form_args = dict(value=dict(default=str(uuid.uuid4())))

--- a/endpoint/packages/user/model.py
+++ b/endpoint/packages/user/model.py
@@ -54,7 +54,8 @@ class Group(db.Model):
     name = db.Column(db.String(100), nullable=False)
     description = db.Column(db.String(100))
 
-    members = db.relationship("User", secondary=membership_table, backref="groups")
+    members = db.relationship("User", secondary=membership_table,
+                              backref="groups")
 
     def __repr__(self):
         return self.name
@@ -64,16 +65,12 @@ class Token(db.Model):
     __tablename__ = "tokens"
 
     id = db.Column(db.Integer, primary_key=True)
-    _value = db.Column(db.String(100), nullable=True)
+    value = db.Column(db.String(100), nullable=True)
     owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     owner = db.relationship("User", backref="tokens")
 
     def __init__(self):
-        self._value = str(uuid.uuid4())
-
-    @property
-    def value(self):
-        return self._value
+        self.value = str(uuid.uuid4())
 
     def __repr__(self):
-        return self._value
+        return self.value


### PR DESCRIPTION
The token value should be an auto generated UUID by default, but should
be editable so that it can be replaced by an account number string or token
provided by an external service which is not using UUIDs.