### PR TITLE
Add logic to twilio endpoint for archiving links on wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.db
 .DS_Store
+*.cfg

--- a/endpoint/main.py
+++ b/endpoint/main.py
@@ -7,10 +7,11 @@ import packages
 
 
 app = Flask(__name__)
-admin = Admin(app, name='endpoint', template_mode='bootstrap3')
+admin = Admin(app, name="endpoint", template_mode="bootstrap3")
 
 
 def init():
-    app.config.from_object('endpoint.default_config')
+    app.config.from_object("endpoint.default_config")
+    app.config.from_pyfile("endpoint.cfg", silent=True)
     init_db(app)
     packages.init(app, admin)

--- a/endpoint/packages/twilio/__init__.py
+++ b/endpoint/packages/twilio/__init__.py
@@ -1,5 +1,10 @@
 from views import bp
+from link_archiver import mediawiki_bot
 
 
 def init(app, admin):
     app.register_blueprint(bp, url_prefix='/twilio')
+    mediawiki_bot.init(
+        app.config["WIKI_URL"],
+        app.config["WIKI_USERNAME"],
+        app.config["WIKI_PASSWORD"])

--- a/endpoint/packages/twilio/link_archiver.py
+++ b/endpoint/packages/twilio/link_archiver.py
@@ -1,0 +1,4 @@
+import mediawiki
+
+
+mediawiki_bot = mediawiki.Bot()

--- a/endpoint/packages/twilio/views.py
+++ b/endpoint/packages/twilio/views.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, Response
+from flask import Blueprint, request, Response, current_app
+from link_archiver import mediawiki_bot
 import permissions
 import urlmarker
 import re
@@ -11,6 +12,9 @@ bp = Blueprint('twilio_views', __name__, template_folder='templates')
 @permissions.accountsid_matches_token
 def receive_sms(**kwargs):
     sms_body = request.form.get("Body")
-    print re.findall(urlmarker.WEB_URL_REGEX, sms_body)
-    xml_response = "<Response><Message>Thanks!</Message></Response>"
+    links = re.findall(urlmarker.WEB_URL_REGEX, sms_body)
+    mediawiki_bot.login()
+    for link in links:
+        mediawiki_bot.append_url(current_app.config["WIKI_PAGE"], link)
+    xml_response = "<Response><Message>Thanks</Message></Response>"
     return Response(xml_response, mimetype="text/xml")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ alembic
 passlib
 Flask-Login
 Flask-admin
+git+https://github.com/ilmarinen/mediawiki.git@v5#egg=mediawiki


### PR DESCRIPTION
Add logic to twilio endpoint to archive links on the wiki
using the mediawiki bot project.